### PR TITLE
Custom format and custom year range for date picker fields

### DIFF
--- a/lib/class_functions.php
+++ b/lib/class_functions.php
@@ -2243,13 +2243,24 @@ class WP_CRM_F {
       switch ($attribute['input_type']) {
 
         case 'date':
+          $additional_attributes = " data-date-format='{$attribute['date_format']}' data-year-range='{$attribute['date_range']}'";
+          $class .= ' wp_crm_date_alt_field';
+          foreach ($values as $rand => $value_data) {
+            ?>
+            <div class="wp_crm_input_wrap"  data-random-hash="<?php echo $rand; ?>" >
+                <input <?php echo $tabindex; ?> class="<?php echo $class; ?> " placeholder="<?php echo isset( $args['placeholder'] ) ? $args['placeholder'] : ''; ?>" type="text" value="<?php echo esc_attr($value_data['value']); ?>" <?php echo $additional_attributes ?>>
+                <input data-crm-slug="<?php echo esc_attr($slug); ?>" data-random-hash="<?php echo $rand; ?>" name="wp_crm[user_data][<?php echo $slug; ?>][<?php echo $rand; ?>][value]" class="wp_crm_date_real_field" type="hidden" value="<?php echo esc_attr($value_data['value']); ?>" />
+            </div>
+            <?php
+          }
+        break;
+
         case 'password':
         case 'text':
-          $input_type = in_array($attribute['input_type'], array('date')) ? 'text' : $attribute['input_type'];
           foreach ($values as $rand => $value_data) {
             ?>
               <div class="wp_crm_input_wrap"  data-random-hash="<?php echo $rand; ?>" >
-                <input <?php echo !empty($tabindex)?$tabindex:''; ?> data-crm-slug="<?php echo esc_attr($slug); ?>" data-random-hash="<?php echo $rand; ?>" name="wp_crm[user_data][<?php echo $slug; ?>][<?php echo $rand; ?>][value]"  <?php echo ($class) ? 'class="' . $class . '"' : ''; ?> type="<?php echo $input_type; ?>" value="<?php echo ($slug != 'user_pass') ? esc_attr($value_data['value']) : ''; ?>" placeholder="<?php echo $args['placeholder'] ?>"/>
+                <input <?php echo !empty($tabindex)?$tabindex:''; ?> data-crm-slug="<?php echo esc_attr($slug); ?>" data-random-hash="<?php echo $rand; ?>" name="wp_crm[user_data][<?php echo $slug; ?>][<?php echo $rand; ?>][value]"  <?php echo ($class) ? 'class="' . $class . '"' : ''; ?> type="<?php echo $attribute['input_type']; ?>" value="<?php echo ($slug != 'user_pass') ? esc_attr($value_data['value']) : ''; ?>" placeholder="<?php echo $args['placeholder'] ?>"/>
             <?php if ( !empty($attribute['has_options']) ) { ?>
                   <select wp_crm_option_for="<?php echo esc_attr($slug); ?>"  <?php echo !empty($tabindex)?$tabindex:''; ?> class="wp_crm_input_options" data-random-hash="<?php echo $rand; ?>" name="wp_crm[user_data][<?php echo $slug; ?>][<?php echo $rand; ?>][option]">
                     <option></option>
@@ -2358,12 +2369,20 @@ class WP_CRM_F {
       switch ($attribute['input_type']) {
 
         case 'date':
-        case 'password':
-        case 'text':
-          $input_type = in_array($attribute['input_type'], array('date')) ? 'text' : $attribute['input_type'];
+          $additional_attributes = " data-date-format='{$attribute['date_format']}' data-year-range='{$attribute['date_range']}'";
           foreach ($values as $rand => $value_data) {
             ?>
-            <input <?php echo $tabindex; ?> data-crm-slug="<?php echo esc_attr($slug); ?>" data-random-hash="<?php echo $rand; ?>" name="wp_crm[user_data][<?php echo $slug; ?>][<?php echo $rand; ?>][value]"  class="input-large wp_crm_<?php echo $slug; ?>_field <?php echo $class; ?>" type="<?php echo $input_type; ?>" value="<?php echo ($slug != 'user_pass') ? esc_attr($value_data['value']) : ''; ?>" placeholder="<?php echo isset( $args['placeholder'] ) ? $args['placeholder'] : ''; ?>" />
+            <input <?php echo $tabindex; ?> class="input-large wp_crm_<?php echo $slug; ?>_field <?php echo $class; ?> wp_crm_date_alt_field" placeholder="<?php echo isset( $args['placeholder'] ) ? $args['placeholder'] : ''; ?>" type="text" value="<?php echo esc_attr($value_data['value']); ?>" <?php echo $additional_attributes ?>>
+            <input data-crm-slug="<?php echo esc_attr($slug); ?>" data-random-hash="<?php echo $rand; ?>" name="wp_crm[user_data][<?php echo $slug; ?>][<?php echo $rand; ?>][value]" class="wp_crm_date_real_field" type="hidden" value="<?php echo esc_attr($value_data['value']); ?>" />
+          <?php
+          }
+          break;
+
+        case 'password':
+        case 'text':
+          foreach ($values as $rand => $value_data) {
+            ?>
+            <input <?php echo $tabindex; ?> data-crm-slug="<?php echo esc_attr($slug); ?>" data-random-hash="<?php echo $rand; ?>" name="wp_crm[user_data][<?php echo $slug; ?>][<?php echo $rand; ?>][value]"  class="input-large wp_crm_<?php echo $slug; ?>_field <?php echo $class; ?>" type="<?php echo $attribute['input_type']; ?>" value="<?php echo ($slug != 'user_pass') ? esc_attr($value_data['value']) : ''; ?>" placeholder="<?php echo isset( $args['placeholder'] ) ? $args['placeholder'] : ''; ?>" />
             <?php if ( !empty($attribute['has_options']) ) { ?>
               <select wp_crm_option_for="<?php echo esc_attr($slug); ?>" <?php echo $tabindex; ?> class="input-small wp_crm_input_options" data-random-hash=""<?php echo $rand; ?>" name="wp_crm[user_data][<?php echo $slug; ?>][<?php echo $rand; ?>][option]">
                 <option></option>

--- a/lib/ui/crm_page_wp_crm_settings.php
+++ b/lib/ui/crm_page_wp_crm_settings.php
@@ -521,11 +521,16 @@ if(empty($wp_crm['data_structure']['attributes'])) {
             <?php if($slug == 'recaptcha'): ?>
               <input value="recaptcha" type="hidden" name="wp_crm[data_structure][attributes][recaptcha][input_type]" />
             <?php endif; ?>
-              <select name="wp_crm[data_structure][attributes][<?php echo $slug; ?>][input_type]" data-slug="<?php echo $slug; ?>" data-input-type="<?php echo $wp_crm['data_structure']['attributes'][$slug]['input_type']; ?>" <?php if($slug == 'recaptcha') echo 'disabled="disabled"'; ?> >
+              <select name="wp_crm[data_structure][attributes][<?php echo $slug; ?>][input_type]" data-slug="<?php echo $slug; ?>" data-input-type="<?php echo $wp_crm['data_structure']['attributes'][$slug]['input_type']; ?>" <?php if($slug == 'recaptcha') echo 'disabled="disabled"'; ?> class="wp_crm_select_input_type">
                 <?php foreach($wp_crm['configuration']['input_types'] as $this_input_type_slug => $this_input_type_label) { ?>
                 <option data-input-type-label="<?php echo $this_input_type_label; ?>" data-input-type-slug="<?php echo $this_input_type_slug; ?>"  value="<?php echo $this_input_type_slug; ?>" <?php selected( isset( $wp_crm['data_structure']['attributes'][$slug]['input_type'] ) ? $wp_crm['data_structure']['attributes'][$slug]['input_type'] : 'text', $this_input_type_slug ); ?> <?php if($this_input_type_slug == 'recaptcha') echo 'disabled="disabled"'; ?>><?php echo $this_input_type_label; ?></option>
                 <?php }; ?>
             </select>
+            <div class="wp_crm_date_field_additional_config" style="display:none">
+                <input type="text" name="wp_crm[data_structure][attributes][<?php echo $slug; ?>][date_format]" value="<?php echo (isset($data['date_format'])) ? $data['date_format'] : '' ?>" placeholder="<?php _e( 'Format (e.g., dd/mm/yy)', ud_get_wp_crm()->domain ) ?>">
+                <input type="text" name="wp_crm[data_structure][attributes][<?php echo $slug; ?>][date_range]" value="<?php echo (isset($data['date_range'])) ? $data['date_range'] : '' ?>" placeholder="<?php _e( 'Year Range (e.g., -50:+10)', ud_get_wp_crm()->domain ) ?>">
+                <small><?php printf( __( 'For possible values see <i>dateFormat</i> and <i>yearRange</i> options at <a href="%s" target="_blank">jQuery UI datepicker docs.</a>', ud_get_wp_crm()->domain ), "http://api.jqueryui.com/datepicker/" ) ?></small>
+            </div>
           </td>
 
           <td class='wp_crm_values_col'>

--- a/static/scripts/crm_page_wp_crm_settings.js
+++ b/static/scripts/crm_page_wp_crm_settings.js
@@ -16,6 +16,10 @@ jQuery(document).ready(function() {
         return;
     }), jQuery("#wp_crm_attribute_fields tbody").sortable({
         delay: 50
+    }), jQuery("#wp_crm_attribute_fields").on("change", ".wp_crm_select_input_type", function() {
+        jQuery(this).next(".wp_crm_date_field_additional_config").toggle("date" == jQuery(this).val());
+    }), jQuery(".wp_crm_select_input_type").each(function() {
+        jQuery(this).change();
     }), jQuery("#wp_crm_show_settings_array, #wp_crm_show_settings_array_cancel").click(function() {
         jQuery("#wp_crm_show_settings_array_result").is(":visible") ? (jQuery("#wp_crm_show_settings_array_cancel").hide(), 
         jQuery("#wp_crm_show_settings_array_result").hide()) : (jQuery("#wp_crm_show_settings_array_cancel").show(), 

--- a/static/scripts/src/crm_page_wp_crm_settings.js
+++ b/static/scripts/src/crm_page_wp_crm_settings.js
@@ -60,6 +60,13 @@ jQuery(document).ready(function() {
     delay: 50
   });
 
+  jQuery("#wp_crm_attribute_fields").on('change', '.wp_crm_select_input_type', function() {
+    jQuery(this).next('.wp_crm_date_field_additional_config').toggle('date' == jQuery(this).val());
+  });
+  jQuery('.wp_crm_select_input_type').each(function() {
+    jQuery(this).change();
+  })
+
   /** Show settings array */
   jQuery("#wp_crm_show_settings_array, #wp_crm_show_settings_array_cancel").click(function() {
     if(jQuery("#wp_crm_show_settings_array_result").is(":visible")) {

--- a/static/scripts/src/wp_crm_profile_editor.js
+++ b/static/scripts/src/wp_crm_profile_editor.js
@@ -60,11 +60,27 @@ jQuery(document).ready(function() {
   }
 
   if(typeof jQuery.fn.datepicker == 'function') {
-    jQuery('input.wpc_date_picker').datepicker({
+    var datepicker_default_opts = {
       dateFormat: 'yy-mm-dd',
       changeMonth: true,
       changeYear: true
-    });
+    };
+    jQuery('input.wpc_date_picker').each(function() {
+      var datepicker_opts = datepicker_default_opts,
+          dateFormat = jQuery(this).attr('data-date-format'),
+          yearRange = jQuery(this).attr('data-year-range');
+      if ('' != dateFormat) {
+        datepicker_opts['altFormat'] = 'yy-mm-dd';
+      }
+      if ('' != yearRange) {
+        datepicker_opts['yearRange'] = yearRange;
+      }
+      datepicker_opts['altField'] = jQuery(this).next('.wp_crm_date_real_field');
+      jQuery(this).datepicker(datepicker_opts);
+      if ('' != dateFormat) {
+          jQuery(this).datepicker('option', { 'dateFormat' : dateFormat });
+      }
+  });
   }
 
 

--- a/static/scripts/wp_crm_profile_editor.js
+++ b/static/scripts/wp_crm_profile_editor.js
@@ -41,11 +41,22 @@ jQuery(document).bind("wp_crm_value_changed", function(event, data) {
             });
         });
     }
-    "function" == typeof jQuery.fn.datepicker && jQuery("input.wpc_date_picker").datepicker({
-        dateFormat: "yy-mm-dd",
-        changeMonth: !0,
-        changeYear: !0
-    }), jQuery(".wp_crm_attribute_uneditable:not(div)").each(function() {
+    if ("function" == typeof jQuery.fn.datepicker) {
+        var datepicker_default_opts = {
+            dateFormat: "yy-mm-dd",
+            changeMonth: !0,
+            changeYear: !0
+        };
+        jQuery("input.wpc_date_picker").each(function() {
+            var datepicker_opts = datepicker_default_opts, dateFormat = jQuery(this).attr("data-date-format"), yearRange = jQuery(this).attr("data-year-range");
+            "" != dateFormat && (datepicker_opts.altFormat = "yy-mm-dd"), "" != yearRange && (datepicker_opts.yearRange = yearRange), 
+            datepicker_opts.altField = jQuery(this).next(".wp_crm_date_real_field"), jQuery(this).datepicker(datepicker_opts), 
+            "" != dateFormat && jQuery(this).datepicker("option", {
+                dateFormat: dateFormat
+            });
+        });
+    }
+    jQuery(".wp_crm_attribute_uneditable:not(div)").each(function() {
         var value, chkBoxs, placeholder, this_element = jQuery(this), this_class = this_element.attr("class");
         this_element.attr("data-crm-slug");
         this_element.is("select") ? value = this_element.find(":selected").html() : this_element.is(":checkbox") ? (chkBoxs = this_element.closest(".wp_crm_checkbox_list").find("input[type=checkbox]"), 


### PR DESCRIPTION
As the default format (yy-mm-dd) is really bad for non-english users I've had this idea of creating two additional fields just for date pickers. This way the real date field is hidden (and continues with the yyyy-mm-dd format)  but a fake one is shown with the desired format (using altField/altFormat datepicker ui options).
This PR also solves the #41 problem, letting the user define what range to show.

I've tested it a little bit here and for me works as expected. I really hope this helps you guys to improve the plugin :)

As English is not my first language feel free to correct any grammar mistakes.