### PR TITLE
Release 1.1.6

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,9 @@
+#### 1.1.6 ( April 30, 3018 )
+* Fixed pagination function for messages on a user page, which crashed property list pagination in WP-Property plugin.
+* Turned on Google Visualization Feature.
+* Removed duplicated options.
+* Security fix added. Scripts no longer can be sent via a contact form or admin message.
+
 #### 1.1.5 ( March 22, 2018 )
 * Added French translation.
 * Added data sanitization of the form filling.

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "constant": "WP_CRM_VISUALIZATION",
         "description": "Google graph visualization on overview page.",
         "since": "1.1.0",
-        "enabled": false
+        "enabled": true
       },
       {
         "name": "Color Schemes",

--- a/lib/class_ajax.php
+++ b/lib/class_ajax.php
@@ -84,12 +84,22 @@ if ( !class_exists( 'WP_CRM_AJAX' ) ) {
      * Insert activity message
      */
     static function insert_activity_message() {
+      $message = $_REQUEST["content"];
+      $message = wp_kses($message, array(
+        'a' => array(
+          'href' => array(),
+          'title' => array()
+        ),
+        'br' => array(),
+        'em' => array(),
+        'strong' => array(),
+      ));
       die( WP_CRM_F::insert_event(
         array(
           'time' => $_REQUEST["time"],
           'attribute' => !empty( $_REQUEST["message_type"] ) ? $_REQUEST["message_type"] : "note",
           'object_id' => $_REQUEST["user_id"],
-          'text' => $_REQUEST["content"],
+          'text' => $message,
           'ajax' => 'true'
         )
       ));

--- a/lib/class_contact_messages.php
+++ b/lib/class_contact_messages.php
@@ -1506,11 +1506,6 @@ class class_contact_messages {
                       <span class="description"><?php _e( 'Form request method.', ud_get_wp_crm()->domain ); ?></span>
                     </li>
 
-                    <li>
-                      <label for="redirect_to_<?php echo $row_hash; ?>"><?php _e( 'Redirect to:', ud_get_wp_crm()->domain ); ?></label>
-                      <input type="text" id="redirect_to_<?php echo $row_hash; ?>" class="regular-text" name="wp_crm[wp_crm_contact_system_data][<?php echo $contact_form_slug; ?>][redirect_url]" value="<?php echo !empty($data[ 'redirect_url' ])?$data[ 'redirect_url' ]:''; ?>"/>
-                    </li>
-
                     <li class="wp_crm_checkbox_on_left">
                       <input <?php checked( !empty( $data[ 'message_field' ] ) ? $data[ 'message_field' ] : '', 'on' ); ?> id="message_<?php echo $row_hash; ?>" type="checkbox" name="wp_crm[wp_crm_contact_system_data][<?php echo $contact_form_slug; ?>][message_field]" value="on" value="<?php echo !empty( $data[ 'message_field' ] ) ? $data[ 'message_field' ] : ''; ?>"/>
                       <label for="message_<?php echo $row_hash; ?>"><?php _e( 'Display textarea for custom message.', ud_get_wp_crm()->domain ); ?></label>

--- a/lib/class_core.php
+++ b/lib/class_core.php
@@ -286,7 +286,6 @@ class WP_CRM_Core {
    */
   static function toplevel_page_wp_crm() {
     add_screen_option( 'layout_columns', array( 'max' => 2, 'default' => 2 ) );
-    add_screen_option( 'per_page', array( 'label' => __( 'Users', ud_get_wp_crm()->domain ) ) );
 
     //** Top level page contextual help data */
     $contextual_help[ 'General Help' ][ ] = '<p>' . __( 'This page is used to filter and find various users. Visit the Settings page to select which attributes to show on the overview.', ud_get_wp_crm()->domain ) . '</p>';

--- a/lib/class_functions.php
+++ b/lib/class_functions.php
@@ -2859,12 +2859,9 @@ class WP_CRM_F {
    * @return $value|false
    * @author odokienko@UD
    */
-  static function crm_set_option($status = false, $option = false, $value = false) {
-    if ($status || !$option) {
-      return false;
-    } elseif ('crm_page_wp_crm_add_new_per_page' == $option) {
-      return $value;
-    }
+  static function crm_set_option($status, $option, $value) {
+    if ( 'crm_page_wp_crm_add_new_per_page' == $option ) return $value;
+    return $status;
   }
 
   /*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wp-crm",
   "title": "WP-CRM",
   "description": "This plugin is intended to significantly improve user management, easily create contact forms, and keep track of incoming shortcode form messages.",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "homepage": "https://usabilitydynamics.com/products/wp-crm/",
   "author": {
     "name": "UsabilityDynamics, Inc.",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://www.usabilitydynamics.com/product/wp-crm/
 Tags: wp-crm, users, CRM, user management, contact form, shortcode form, email, feedback, form, contact form plugin, WordPress CRM, contact form builder, newsletters, bbpress
 Requires at least: 4.0
 Tested up to: 4.9.4
-Stable tag: 1.1.5
+Stable tag: 1.1.6
 License: GPLv2 or later
 Organize your business clients, improve user management.
 
@@ -74,6 +74,12 @@ For additional help, please reference the contextual help dropdowns the differen
 * Initial public release.
 
 == Changelog ==
+
+= 1.1.6 =
+* Fixed pagination function for messages on a user page, which crashed property list pagination in WP-Property plugin.
+* Turned on Google Visualization Feature.
+* Removed duplicated options.
+* Security fix added. Scripts no longer can be sent via a contact form or admin message.
 
 = 1.1.5 =
 * Added French translation.

--- a/wp-crm.php
+++ b/wp-crm.php
@@ -4,9 +4,9 @@
  * Plugin URI: https://www.usabilitydynamics.com/product/wp-crm/
  * Description: This plugin is intended to significantly improve user management, easily create contact forms, and keep track of incoming shortcode form messages.
  * Author: Usability Dynamics, Inc.
- * Version: 1.1.5
+ * Version: 1.1.6
  * Requires at least: 4.0
- * Tested up to: 4.9.4
+ * Tested up to: 4.9.5
  * Text Domain: wp-crm
  * Author URI: https://www.usabilitydynamics.com
  * GitHub Plugin URI: wp-crm/wp-crm
@@ -20,7 +20,7 @@
 
 /** Plugin Version */
 if ( !defined( 'WP_CRM_Version' ) ) {
-  define('WP_CRM_Version', '1.1.5');
+  define('WP_CRM_Version', '1.1.6');
 }
 
 /** Path for Includes */


### PR DESCRIPTION
* Fixed pagination function for messages on a user page, which crashed property list pagination in WP-Property plugin
* Turned on Google Visualization Feature flag
* Removed duplicated options
* Security fix. Scripts no longer can be sent via a contact form or admin message.