### PR TITLE
php warning

### DIFF
--- a/lib/class_default_api.php
+++ b/lib/class_default_api.php
@@ -690,7 +690,7 @@ if( !function_exists( 'wp_crm_save_user_data' ) ) {
               //* Do not save empty values until this is being done on the profile editing page */
               if( isset( $data[ 'value' ] ) ) {
                 if( ( !isset( $args[ 'admin_save_action' ] ) || !$args[ 'admin_save_action' ] ) && empty( $data[ 'value' ] ) ) {
-                  continue;
+                  continue 2;
                 }
               }
 


### PR DESCRIPTION
This should fix warning:

PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in /var/www/wp-content/plugins/wp-crm/lib/class_default_api.php on line 693